### PR TITLE
Abstract DFS data loading from shapefile data loading

### DIFF
--- a/consumer_flex_app/demand_flexibility_service/app.py
+++ b/consumer_flex_app/demand_flexibility_service/app.py
@@ -53,12 +53,11 @@ def page_header() -> None:
 
 # Load in the data
 @st.experimental_memo
-def get_all_data():
+def get_dfs_data():
     paths = get_dfs_paths()
     bids, requirements, summary = get_dfs_dataframes(paths)
-    dno_regions = get_dno_regions()
     event_summary = get_event_summary(requirements, summary)
-    return dno_regions, event_summary, bids
+    return event_summary, bids
 
 
 def get_previous_dfs_date(dfs_date: str, all_dfs_dates: list[str]) -> str:
@@ -68,7 +67,8 @@ def get_previous_dfs_date(dfs_date: str, all_dfs_dates: list[str]) -> str:
 
 def main() -> None:
     global get_previous_dfs_date
-    dno_regions, event_summary, bids = get_all_data()
+    dno_regions = get_dno_regions()
+    event_summary, bids = get_dfs_data()
     dfs_metrics = get_metrics_by_dfs_event(bids, event_summary)
 
     DFS_DATES: list = sorted(event_summary["Date"].unique())

--- a/consumer_flex_app/demand_flexibility_service/app.py
+++ b/consumer_flex_app/demand_flexibility_service/app.py
@@ -1,3 +1,4 @@
+import datetime
 from functools import partial
 
 import pandas as pd
@@ -52,7 +53,7 @@ def page_header() -> None:
 
 
 # Load in the data
-@st.experimental_memo
+@st.experimental_memo(ttl=datetime.timedelta(hours=1))
 def get_dfs_data():
     paths = get_dfs_paths()
     bids, requirements, summary = get_dfs_dataframes(paths)

--- a/consumer_flex_app/demand_flexibility_service/loaders.py
+++ b/consumer_flex_app/demand_flexibility_service/loaders.py
@@ -2,6 +2,7 @@ import enum
 
 import geopandas as gpd
 import pandas as pd
+import streamlit as st
 from clumper import Clumper
 
 
@@ -67,6 +68,7 @@ def get_dfs_dataframes(paths) -> pd.DataFrame:
     return bids, requirements, summary
 
 
+@st.experimental_memo(persist="disk")
 def get_dno_regions() -> pd.DataFrame:
     SHAPEFILE_FILEPATH = (
         Clumper.read_json(ESO_DNO_LICENSE_AREAS_DATAPACKAGE)


### PR DESCRIPTION
This PR abstracts DFS data loading from shapefile data loading. That allows us to refactor our caching to hopefully improve performance, as described in #1 .

Explicitly:
* We add a TTL for the DFS data, defaulting to 1 hour (so it will check for new DFS data once per hour)
* Will load the DNO regions and persist on disk (since this is unlikely to change at all)

For more info, see explicit commit messages.