### PR TITLE
Add garbage collection

### DIFF
--- a/consumer_flex_app/demand_flexibility_service/app.py
+++ b/consumer_flex_app/demand_flexibility_service/app.py
@@ -1,4 +1,5 @@
 import datetime
+import gc
 from functools import partial
 
 import pandas as pd
@@ -19,6 +20,8 @@ from consumer_flex_app.demand_flexibility_service.transform import (
     get_event_summary,
     get_metrics_by_dfs_event,
 )
+
+gc.enable()
 
 
 def page_header() -> None:
@@ -224,6 +227,8 @@ def main() -> None:
             tab_specific_event,
             day_ahead_flex_by_event_day_region.loc[selected_dfs_event],
         )
+
+    gc.collect()
 
 
 if __name__ == "__main__":

--- a/consumer_flex_app/demand_flexibility_service/render.py
+++ b/consumer_flex_app/demand_flexibility_service/render.py
@@ -1,3 +1,4 @@
+import gc
 import math
 
 import geopandas as gpd
@@ -6,6 +7,8 @@ import pydeck as pdk
 import seaborn as sns
 import streamlit as st
 from millify import millify
+
+gc.enable()
 
 ENERGY_PREFIXES = ["kWh", "MWh", "GWh"]
 POWER_PREFIXES = ["kW", "MW", "GW"]
@@ -165,6 +168,7 @@ def render_metrics(
             """
         )
 
+    gc.collect()
     return None
 
 
@@ -210,3 +214,5 @@ def render_map(tab, gdf: gpd.GeoDataFrame):
         """
         )
     tab.pydeck_chart(deck, use_container_width=True)
+    gc.collect()
+    return None


### PR DESCRIPTION
Use the inbuilt `gc` module to periodically `gc.collect()`. This should stop memory leaks from accumulating and us running out of resources on Streamlit cloud.

The current solution is a little clunky, but we can probably optimise it more later on.

Partially closes #1 .