### PR TITLE
Add helpful pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,7 @@ repos:
         args: ["--py37-plus"]
       - id: nbqa-isort
         args: ["--float-to-top"]
+  - repo: https://github.com/python-poetry/poetry
+    rev: 1.3.2
+    hooks:
+      - id: poetry-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,14 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
+      - id: check-json
       - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-shebang-scripts-are-executable
+      - id: check-added-large-files
       - id: name-tests-test
         args: ["--pytest-test-first"]
   - repo: https://github.com/psf/black


### PR DESCRIPTION
This is a small PR that adds some helpful pre-commit hooks. These include:
* Standard pre-commit checks - don't commit large files, check `{json|toml}` parseable, check for merge conflicts, check that bash scripts are executable and check large files arent commited to git
* Poetry specific git hook, to check that the `pyproject.toml` isnt weird