### PR TITLE
refactor: :art: Remove the need for global function import

### DIFF
--- a/consumer_flex_app/demand_flexibility_service/app.py
+++ b/consumer_flex_app/demand_flexibility_service/app.py
@@ -64,20 +64,19 @@ def get_dfs_data():
     return event_summary, bids
 
 
-def get_previous_dfs_date(dfs_date: str, all_dfs_dates: list[str]) -> str:
+def _get_previous_dfs_date(dfs_date: str, all_dfs_dates: list[str]) -> str:
     # If the specified dfs_date is first in the list, the previous one equals itself
     return all_dfs_dates[max(0, all_dfs_dates.index(dfs_date) - 1)]
 
 
 def main() -> None:
-    global get_previous_dfs_date
     dno_regions = get_dno_regions()
     event_summary, bids = get_dfs_data()
     dfs_metrics = get_metrics_by_dfs_event(bids, event_summary)
 
     DFS_DATES: list = sorted(event_summary["Date"].unique())
     LATEST_DFS_EVENT_DATE = DFS_DATES[-1]
-    get_previous_dfs_date = partial(get_previous_dfs_date, all_dfs_dates=DFS_DATES)
+    get_previous_dfs_date = partial(_get_previous_dfs_date, all_dfs_dates=DFS_DATES)
 
     tab_overall, tab_latest_event, tab_specific_event, tab_compare_event = st.tabs(
         ["Overall", "Latest DFS Event", "Specific DFS Event", "Compare DFS Events"]

--- a/tests/demand_flexibility_service/test_app.py
+++ b/tests/demand_flexibility_service/test_app.py
@@ -1,6 +1,6 @@
 import pytest
 
-from consumer_flex_app.demand_flexibility_service.app import get_previous_dfs_date
+from consumer_flex_app.demand_flexibility_service.app import _get_previous_dfs_date
 
 
 @pytest.fixture
@@ -11,10 +11,10 @@ def fake_dfs_dates() -> list[str]:
 class TestGetPreviousDFSDate:
     def test_get_previous_dfs_date_returns_previous_value_in_list(self, fake_dfs_dates):
         for dfs_date, previous_dfs_date in zip(fake_dfs_dates[1:], fake_dfs_dates[:-1]):
-            assert get_previous_dfs_date(dfs_date, fake_dfs_dates) == previous_dfs_date
+            assert _get_previous_dfs_date(dfs_date, fake_dfs_dates) == previous_dfs_date
 
     def test_get_previous_dfs_date_returns_initial_value_on_first_date(
         self, fake_dfs_dates
     ):
         first_dfs_date = fake_dfs_dates[0]
-        assert get_previous_dfs_date(first_dfs_date, fake_dfs_dates) == first_dfs_date
+        assert _get_previous_dfs_date(first_dfs_date, fake_dfs_dates) == first_dfs_date


### PR DESCRIPTION
The function was poorly named, we should rename it to be an internal function to remove the need of having to specify `global` within the main function. This might prevent memory leakages, but unsure.

I never liked it there anyway, so best remove it!