### PR TITLE
Hotfix: Reindex error due to date parsing

### DIFF
--- a/consumer_flex_app/demand_flexibility_service/render.py
+++ b/consumer_flex_app/demand_flexibility_service/render.py
@@ -118,12 +118,14 @@ def render_metrics(
             dfs_metrics.dfs_procured_day_ahead_mw
         ).median()
         if overall
-        else dfs_metrics.at[dfs_date_1, "dfs_procured_mw"]
-        or dfs_metrics.at[dfs_date_1, "dfs_procured_day_ahead_mw"]
+        else dfs_metrics.dfs_procured_mw.fillna(
+            dfs_metrics.dfs_procured_day_ahead_mw
+        ).at[dfs_date_1]
     ).round(2)
     procured_mw_2 = (
-        dfs_metrics.at[dfs_date_2, "dfs_procured_mw"]
-        or dfs_metrics.at[dfs_date_2, "dfs_procured_day_ahead_mw"]
+        dfs_metrics.dfs_procured_mw.fillna(dfs_metrics.dfs_procured_day_ahead_mw).at[
+            dfs_date_2
+        ]
     ).round(2)
     procured_mw_delta = None if overall else (procured_mw - procured_mw_2).round(2)
 


### PR DESCRIPTION
This hotfix PR addresses two issues:

1. In the flexibility event on 13th Feb, some of the bids had date `13/02/2023` rather than the usual `2023-02-13`. I added better parsing to detect and deal with this, so the app renders
2. The `procured_mw` was not infilling the day-ahead value when there was no `D0` value.

Now the app should work as intended, but this is tech debt we should fix in a later refactor.