### PR TITLE
fix(map): :bug: Only calculate total flex per region on the overall tab

### DIFF
--- a/consumer_flex_app/demand_flexibility_service/app.py
+++ b/consumer_flex_app/demand_flexibility_service/app.py
@@ -203,7 +203,7 @@ def main(
 
     tab_overall.write("### 🗓️ By date and provider")
     tab_overall.bar_chart(total_bids_by_date_provider.unstack().round(2))
-    render_map(tab_overall, day_ahead_flex_cumulative_by_region)
+    render_map(tab_overall, day_ahead_flex_cumulative_by_region, overall=True)
     render_map(
         tab_latest_event, day_ahead_flex_by_event_day_region.loc[LATEST_DFS_EVENT_DATE]
     )

--- a/consumer_flex_app/demand_flexibility_service/render.py
+++ b/consumer_flex_app/demand_flexibility_service/render.py
@@ -174,7 +174,7 @@ def render_metrics(
     return None
 
 
-def render_map(tab, gdf: gpd.GeoDataFrame):
+def render_map(tab, gdf: gpd.GeoDataFrame, overall=False):
     gdf = gdf.to_crs("EPSG:4326").sort_values(by="value")
     gdf["fill_color"] = [
         list(255 * x for x in color) for color in sns.color_palette("Blues", len(gdf))
@@ -186,7 +186,6 @@ def render_map(tab, gdf: gpd.GeoDataFrame):
             "GeoJsonLayer",
             data=gdf,
             get_fill_color="fill_color",
-            # get_fill_color="fill_color",
             filled=True,
             pickable=True,
             wireframe=True,
@@ -194,12 +193,16 @@ def render_map(tab, gdf: gpd.GeoDataFrame):
         )
     ]
 
+    tooltip_text = """DNO Region Name: {LongName}
+        - Average total day-ahead forecasted MW reduction: {value}MW
+    """
+    if overall:
+        tooltip_text += "- Total day-ahead procured flexibility: {flex_mwh}MWh"
+
     deck = pdk.Deck(
         layers,
         initial_view_state=INITIAL_VIEW_STATE,
-        tooltip={
-            "text": "DNO Region Name: {LongName}\n - Average total day-ahead forecasted MW reduction: {value}MW\n - Total day-ahead procured flexibility: {flex_mwh}MWh"
-        },
+        tooltip={"text": tooltip_text},
     )
 
     tab.write("# 📌          Flexibility by region")


### PR DESCRIPTION
Previously, if selecting an individual flex event, the "average flex per region" was essentially calculated twice. We remove this bug, and only calculate the total flex per region when `overall=True` in the map